### PR TITLE
Added '$post' argument to jf_read_more_excerpt()

### DIFF
--- a/functions/jf-content.php
+++ b/functions/jf-content.php
@@ -2,7 +2,7 @@
 
 // Return the excerpt of the post, unless the read more element is used
 // Output of both versions will be the same: one <p> with content and one <p> with the more link
-function jf_read_more_excerpt( ) {
+function jf_read_more_excerpt( $post ) {
   $content = get_the_content();
 
   if( strpos( $content, '#more-' ) ) {

--- a/templates/content/archive.php
+++ b/templates/content/archive.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
   if (have_posts()) :
     while (have_posts()) : the_post(); ?>
     <div id="post-<?php the_ID(); ?>" <?php post_class() ?>>
-      <?php jf_read_more_excerpt(); ?>
+      <?php jf_read_more_excerpt( $post ); ?>
     </div>
   <?php
     endwhile;


### PR DESCRIPTION
The original implimentation was causing `Undefined variable` notifications. Also, in this form the function definition is a bit more explicit about what it is using to generate the excerpt.